### PR TITLE
feat: ensure esm compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Node.js-compatible request and response objects for Compute@Edge JavaScript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "type": "module",
   "directories": {
     "lib": "lib"
   },

--- a/src/http-compute-js/http-incoming.ts
+++ b/src/http-compute-js/http-incoming.ts
@@ -10,7 +10,7 @@
 import type { IncomingHttpHeaders, IncomingMessage } from 'http';
 import { Readable } from 'stream';
 
-import { ERR_METHOD_NOT_IMPLEMENTED } from '../utils/errors';
+import { ERR_METHOD_NOT_IMPLEMENTED } from '../utils/errors.js';
 
 const kHeaders = Symbol('kHeaders');
 const kHeadersDistinct = Symbol('kHeadersDistinct');

--- a/src/http-compute-js/http-outgoing.ts
+++ b/src/http-compute-js/http-outgoing.ts
@@ -24,15 +24,15 @@ import {
   ERR_STREAM_DESTROYED,
   ERR_STREAM_NULL_VALUES,
   ERR_STREAM_WRITE_AFTER_END
-} from '../utils/errors';
-import { isUint8Array, validateString } from '../utils/types';
-import { kNeedDrain, kOutHeaders, utcDate } from './internal-http';
-import { getDefaultHighWaterMark } from './internal-streams-state';
+} from '../utils/errors.js';
+import { isUint8Array, validateString } from '../utils/types.js';
+import { kNeedDrain, kOutHeaders, utcDate } from './internal-http.js';
+import { getDefaultHighWaterMark } from './internal-streams-state.js';
 import {
   checkInvalidHeaderChar,
   checkIsHttpToken,
   chunkExpression as RE_TE_CHUNKED,
-} from './http-common';
+} from './http-common.js';
 
 const kCorked = Symbol('corked');
 const kUniqueHeaders = Symbol('kUniqueHeaders');

--- a/src/http-compute-js/http-server.ts
+++ b/src/http-compute-js/http-server.ts
@@ -16,11 +16,11 @@ import {
   ERR_INVALID_ARG_VALUE,
   ERR_INVALID_CHAR,
   ERR_METHOD_NOT_IMPLEMENTED,
-} from '../utils/errors';
-import { ComputeJsOutgoingMessage, DataWrittenEvent, HeadersSentEvent } from './http-outgoing';
-import { chunkExpression } from './http-common';
-import { ComputeJsIncomingMessage } from './http-incoming';
-import { kOutHeaders } from './internal-http';
+} from '../utils/errors.js';
+import { ComputeJsOutgoingMessage, DataWrittenEvent, HeadersSentEvent } from './http-outgoing.js';
+import { chunkExpression } from './http-common.js';
+import { ComputeJsIncomingMessage } from './http-incoming.js';
+import { kOutHeaders } from './internal-http.js';
 import { EventEmitter } from "events";
 
 /* These items copied from Node.js: node/lib/_http_common.js. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@
 
 /// <reference types="@fastly/js-compute" />
 
-export { ComputeJsIncomingMessage } from './http-compute-js/http-incoming';
-export { ComputeJsOutgoingMessage } from './http-compute-js/http-outgoing';
+export { ComputeJsIncomingMessage } from './http-compute-js/http-incoming.js';
+export { ComputeJsOutgoingMessage } from './http-compute-js/http-outgoing.js';
 export {
   STATUS_CODES,
   createServer,
@@ -17,11 +17,11 @@ export {
   HttpServerOptions,
   ReqRes,
   ToReqResOptions,
-} from './http-compute-js/http-server';
+} from './http-compute-js/http-server.js';
 
 import {
   createServer
-} from './http-compute-js/http-server';
+} from './http-compute-js/http-server.js';
 export default {
   createServer,
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -5,7 +5,7 @@
  * Portions of this file Copyright Joyent, Inc. and other Node contributors. See LICENSE file for details.
  */
 
-import { ERR_INVALID_ARG_TYPE } from './errors';
+import { ERR_INVALID_ARG_TYPE } from './errors.js';
 
 /* These items copied from Node.js: node/lib/internal/validators.js */
 


### PR DESCRIPTION
Thanks for open-sourcing this great project!

This is a quick PR to ensure ESM compatibility by adding `type: module` to the 'package.json' and using file extensions on the imports. Will be useful to be able to use this module for upstream applications.

Fixes #6 