### PR TITLE
fix: set req complete when pushing null

### DIFF
--- a/src/http-compute-js/http-incoming.ts
+++ b/src/http-compute-js/http-incoming.ts
@@ -211,6 +211,7 @@ export class ComputeJsIncomingMessage extends Readable implements IncomingMessag
     if(this._stream == null) {
       // For GET and HEAD requests, the stream would be empty.
       // Simply signal that we're done.
+      this.complete = true;
       this.push(null);
       return;
     }
@@ -220,6 +221,7 @@ export class ComputeJsIncomingMessage extends Readable implements IncomingMessag
       const data = await reader.read();
       if (data.done) {
         // Done with stream, tell Readable we have no more data;
+        this.complete = true;
         this.push(null);
       } else {
         this.push(data.value);


### PR DESCRIPTION
This PR ensures that, when ending the req stream read by pushing `null`, the library also sets `complete = true`

Without this fix, the `end` event without `complete` is interpreted as `aborted` by some consumers, e.g. the [http-proxy](https://github.com/http-party/node-http-proxy) library

This fix also appears to be more in line with the node internals, e.g. https://github.com/nodejs/node/blob/6ce718df60dc4bf2a2fd1d8395e7d3b34ab6511a/lib/_http_common.js#L142-L152