### PR TITLE
chore: add test for streaming

### DIFF
--- a/src/http-compute-js/http-server.test.ts
+++ b/src/http-compute-js/http-server.test.ts
@@ -14,3 +14,22 @@ test("multiple set-cookie headers", async () => {
     "type=ninja, language=javascript"
   );
 });
+
+test("streaming", async () => {
+  const { res: nodeRes } = toReqRes(new Request("https://example.com"));
+
+  nodeRes.writeHead(200);
+  nodeRes.write("hello");
+
+  const webResponse = await toComputeResponse(nodeRes);
+  expect(webResponse.status).toEqual(200);
+  const reader = webResponse.body
+    .pipeThrough(new TextDecoderStream())
+    .getReader();
+
+  expect(await reader.read()).toEqual({ done: false, value: "hello" });
+  nodeRes.write("world");
+  expect(await reader.read()).toEqual({ done: false, value: "world" });
+  nodeRes.end();
+  expect(await reader.read()).toEqual({ done: true, value: undefined });
+});


### PR DESCRIPTION
While debugging something related to streaming, I wanted to make sure that the bug isn't in http-compute-js. So I wrote a barebones test for it, and figured I might as well upstream it!